### PR TITLE
Enhance EyeData object

### DIFF
--- a/moss/eyelink.py
+++ b/moss/eyelink.py
@@ -237,6 +237,13 @@ class EyeData(object):
             Each pair gives the velocity threshold and required duration for the
             respective identification of saccade onsets and offsets.
 
+        Note
+        ----
+        This method currently does not alter any information in the
+        ``fixations`` field , which retains the fixation onset and offset timing
+        assigned by the Eyelink algorithm. As a result, samples might end up
+        being tagged as both a "fixation" and a "saccade".
+
         """
         # Save a copy of the original eyelink saccades
         if not hasattr(self, "eyelink_saccades"):

--- a/moss/eyelink.py
+++ b/moss/eyelink.py
@@ -1,11 +1,15 @@
+from __future__ import division
 import os
+import re
 import subprocess
 import tempfile
 import shutil
 import mimetypes
+import copy
 
 import numpy as np
 import pandas as pd
+from scipy.ndimage import gaussian_filter1d
 
 
 class EyeData(object):
@@ -20,7 +24,7 @@ class EyeData(object):
 
         self.messages = pd.Series(index=pd.Int64Index([], name="timestamp"))
 
-        self.eye_data = []
+        self.samples = []
         self.fixations = []
         self.saccades = []
         self.blinks = []
@@ -32,17 +36,17 @@ class EyeData(object):
             asc_file = fname
         else:
             temp_dir = tempfile.mkdtemp()
-            asc_file = self.edf_to_asc(fname, temp_dir)
+            asc_file = self._edf_to_asc(fname, temp_dir)
 
         # Process the eye data file
-        self.parse_asc_file(asc_file)
+        self._parse_asc_file(asc_file)
 
         # Convert to better representations of the data
-        eye_data = pd.DataFrame(self.eye_data,
-                                columns=["timestamp", "x", "y", "pupil"])
-        self.eye_data = (eye_data.replace({".": np.nan})
-                                 .apply(pd.to_numeric)
-                                 .set_index("timestamp"))
+        samples = pd.DataFrame(self.samples,
+                               columns=["timestamp", "x", "y", "pupil"])
+        self.samples = (samples.replace({".": np.nan})
+                               .apply(pd.to_numeric)
+                               .set_index("timestamp"))
 
         fix_columns = ["start", "end", "duration", "x", "y", "pupil"]
         fixations = pd.DataFrame(self.fixations, columns=fix_columns)
@@ -58,11 +62,18 @@ class EyeData(object):
         blinks = pd.DataFrame(self.blinks, columns=blink_columns)
         self.blinks = blinks.replace({".": np.nan}).apply(pd.to_numeric)
 
+        # Parse some settings
+        sample_settings = self.settings["SAMPLES"]
+        self.units = sample_settings.split()[0]
+
+        m = re.search("RATE (\d+\.00)", sample_settings)
+        self.sampling_rate = float(m.group(1))
+
         # Clean up
         if temp_dir is not None:
             shutil.rmtree(temp_dir)
 
-    def edf_to_asc(self, edf_file, temp_dir):
+    def _edf_to_asc(self, edf_file, temp_dir):
 
         subprocess.call(["edf2asc",
                          "-p", temp_dir,
@@ -76,13 +87,13 @@ class EyeData(object):
 
         return asc_file
 
-    def parse_asc_file(self, asc_file):
+    def _parse_asc_file(self, asc_file):
 
         with open(asc_file) as fid:
             for line in fid:
-                self.parse_line(line)
+                self._parse_line(line)
 
-    def parse_line(self, line):
+    def _parse_line(self, line):
 
         if not line[0].strip():
             return
@@ -119,4 +130,143 @@ class EyeData(object):
         except ValueError:
             return
 
-        self.eye_data.append(fields[:4])
+        self.samples.append(fields[:4])
+
+    def convert_to_degrees(self, width, distance, resolution):
+        """Convert eye position data from pixels to degrees.
+
+        Also changes the origin from the upper right hand corner to the center
+        of the screen.
+
+        Modifies the data inplace and returns self for easy chaining.
+
+        """
+        def recenter_x_data(x):
+            x -= resolution[0] / 2
+
+        def recenter_y_data(y):
+            y -= resolution[1] / 2
+            y *= -1
+
+        def pix_to_deg(data):
+            data *= (width / resolution[0])
+            data /= (distance * 0.017455)
+
+        for field in ["samples", "fixations"]:
+            data = getattr(self, field)
+            recenter_x_data(data["x"])
+            recenter_y_data(data["y"])
+            pix_to_deg(data["x"])
+            pix_to_deg(data["y"])
+
+        for point in ["start", "end"]:
+            recenter_x_data(self.saccades[point + "_x"])
+            recenter_y_data(self.saccades[point + "_y"])
+            pix_to_deg(self.saccades[point + "_x"])
+            pix_to_deg(self.saccades[point + "_y"])
+
+        return self
+
+    def filter_blinks(self):
+        """Remove blinks from saccade and sample data.
+
+        Sample data is set to null between the start and end of saccades
+        that include a blink, and then those saccades are removed from the
+        saccades database.
+
+        Modifies the data inplace and returns self for easy chaining.
+
+        """
+        true_saccades = []
+        for i, s in self.saccades.iterrows():
+            blink = ((self.blinks.start > s.start)
+                     & (self.blinks.end < s.end)
+                     ).any()
+
+            if blink:
+                self.samples.loc[s.start:s.end, ["x", "y"]] = np.nan
+            else:
+                true_saccades.append(i)
+
+        self.saccades = self.saccades.loc[true_saccades].reset_index(drop=True)
+
+        return self
+
+    def reindex_to_experiment_clock(self, start_message="SYNCTIME"):
+        """Convert timing data to seconds from experiment onset.
+
+        Modifies the data inplace and returns self for easy chaining.
+
+        Parameters
+        ----------
+        start_message : str
+            Message text indicating the timepoint of the experiment onset.
+
+        """
+        start_time = self.messages[self.messages == "SYNCTIME"].index.item()
+
+        self.samples.index = (self.samples.index - start_time) / 1000
+
+        def reindex_events(df):
+            cols = ["start", "end"]
+            df.loc[:, cols] = (df[cols] - start_time) / self.sampling_rate
+            df.loc[:, "duration"] /= 1000
+
+        for event_type in ["blinks", "saccades", "fixations"]:
+            reindex_events(getattr(self, event_type))
+
+        return self
+
+    def detect_saccades(self, kernel_sigma=.003,
+                        start_thresh=(20, .005),
+                        end_thresh=(7, .005)):
+        """Detect saccade events, replacing the Eyelink data.
+
+        Assumes that the timestamps have been converted to second resolution
+        and the samples have been converted to degrees.
+
+        Parameters
+        ----------
+        TODO
+
+        """
+        dt = 1 / self.sampling_rate
+        kernel_width = kernel_sigma / dt
+
+        xy = self.samples[["x", "y"]]
+
+        # Smooth the gaze position data
+        xy_s = xy.apply(gaussian_filter1d, args=(kernel_width,))
+
+        # Compute velocity
+        v = xy_s.diff().apply(np.square).sum(axis=1).apply(np.sqrt).divide(dt)
+
+        # Identify saccade onsets
+        start_window = int(start_thresh[1] / dt)
+        sthr = (v > start_thresh[0]).rolling(start_window, center=False).min()
+        ss = v.where(sthr.diff() == 1).dropna().index.values
+
+        # Identify saccade offsets
+        end_window = int(end_thresh[1] / dt)
+        ethr = (v < end_thresh[0]).rolling(end_window, center=False).min()
+        se = v.where(ethr.diff() == -1).dropna().index.values
+
+        # Remove overlapping saccades
+        # TODO these are saccades where the next saccade start time precedes
+        # the current saccade end time.
+        # We'll have to do this recursively in case there are multiple overlaps
+
+        # Determine saccade start and end point
+        saccades = dict(start=ss,
+                        end=se,
+                        start_x=xy.loc[ss, "x"],
+                        start_y=xy.loc[ss, "y"],
+                        end_x=xy.loc[se, "x"],
+                        end_y=xy.loc[se, "y"])
+        saccades = pd.DataFrame(saccades, columns=["x", "y",
+                                                   "start_x", "start_y",
+                                                   "end_x", "end_y"])
+        # Compute amplitude, velocity, and angle
+        # TODO
+
+        self.saccades = saccades


### PR DESCRIPTION
These enhancements make most of the Eyelink file parsing aspects of the class private and add a number of public methods for operating on the data. These include:

- `reindex_to_experiment_clock`: convert all timing information to second units starting at experiment sync time
- `convert_to_degrees`: convert all spatial data to degrees using information about the display
- `filter_blinks`: remove artifactual samples and saccade events that can be attributed to blinks
- `detect_saccades`: custom algorithm for saccade detection

Useful things to add:

Some sort of API for parsing the samples data structure when combined with trial information (given fields in the trial dataframe with trial onset/offset timepoints).